### PR TITLE
v19.0.19, set commandLine=<java>

### DIFF
--- a/manifest
+++ b/manifest
@@ -3,7 +3,42 @@
 JVMLevel=1.8
 LSID=urn\:lsid\:broad.mit.edu\:cancer.software.genepattern.module.analysis\:00072\:999999999
 author=Aravind Subramanian, Pablo Tamayo, Broad Institute
-commandLine=<run-with-env> -u "java/1.8" java <java_flags> -Djava.util.prefs.PreferencesFactory\=com.allaboutbalance.articles.disableprefs.DisabledPreferencesFactory -Djava.awt.headless\=true -cp <libdir>commons-lang3-3.4.jar<path.separator><libdir>commons-io-2.4.jar<path.separator><libdir>commons-cli-1.2.jar<path.separator><libdir>gp-gsea.jar<path.separator><libdir>disable-prefs.jar<path.separator><libdir>gsea-3.0.jar org.genepattern.modules.gsea.GseaWrapper -res <expression.dataset> -cls <phenotype.labels> -collapse <collapse.dataset> -mode <collapsing.mode.for.probe.sets.with.more.than.one.match> -norm <normalization.mode> -nperm <number.of.permutations> -permute <permutation.type> -rnd_type <randomization.mode> -scoring_scheme <scoring.scheme> -metric <metric.for.ranking.genes> -sort <gene.list.sorting.mode> -order <gene.list.ordering.mode> -include_only_symbols <omit.features.with.no.symbol.match> -make_sets <make.detailed.gene.set.report> -median <median.for.class.metrics> -num <number.of.markers> -plot_top_x <plot.graphs.for.the.top.sets.of.each.phenotype> -rnd_seed <random.seed> -save_rnd_lists <save.random.ranked.lists> -set_max <max.gene.set.size> -set_min <min.gene.set.size> <chip.platform.file> -gmx <gene.sets.database> -create_svgs <create.svgs> -create_gcts <create.gcts> -target_profile <target.profile>  <selected.gene.sets> <output.file.name> <alt.delim> -dev_mode <dev.mode> -create_zip <create.zip>
+commandLine=<run-with-env> -u "java/1.8" java <java_flags> \
+    -Djava.util.prefs.PreferencesFactory\=com.allaboutbalance.articles.disableprefs.DisabledPreferencesFactory \
+    -Djava.awt.headless\=true \
+    -cp <libdir>commons-lang3-3.4.jar<path.separator><libdir>commons-io-2.4.jar<path.separator><libdir>commons-cli-1.2.jar<path.separator><libdir>gp-gsea.jar<path.separator><libdir>disable-prefs.jar<path.separator><libdir>gsea-3.0.jar \
+    org.genepattern.modules.gsea.GseaWrapper \
+    -res <expression.dataset> \
+    -cls <phenotype.labels> \
+    -collapse <collapse.dataset> \
+    -mode <collapsing.mode.for.probe.sets.with.more.than.one.match> \
+    -norm <normalization.mode> \
+    -nperm <number.of.permutations> \
+    -permute <permutation.type> \
+    -rnd_type <randomization.mode> \
+    -scoring_scheme <scoring.scheme> \
+    -metric <metric.for.ranking.genes> \
+    -sort <gene.list.sorting.mode> \
+    -order <gene.list.ordering.mode> \
+    -include_only_symbols <omit.features.with.no.symbol.match> \
+    -make_sets <make.detailed.gene.set.report> \
+    -median <median.for.class.metrics> \
+    -num <number.of.markers> \
+    -plot_top_x <plot.graphs.for.the.top.sets.of.each.phenotype> \
+    -rnd_seed <random.seed> \
+    -save_rnd_lists <save.random.ranked.lists> \
+    -set_max <max.gene.set.size> \
+    -set_min <min.gene.set.size> \
+    <chip.platform.file> \
+    -gmx <gene.sets.database> \
+    -create_svgs <create.svgs> \
+    -create_gcts <create.gcts> \
+    -target_profile <target.profile> \
+    <selected.gene.sets> \
+    <output.file.name> \
+    <alt.delim> \
+    -dev_mode <dev.mode> \
+    -create_zip <create.zip>
 cpuType=any
 taskDoc=doc.html
 description=Gene Set Enrichment Analysis

--- a/manifest
+++ b/manifest
@@ -3,7 +3,7 @@
 JVMLevel=1.8
 LSID=urn\:lsid\:broad.mit.edu\:cancer.software.genepattern.module.analysis\:00072\:999999999
 author=Aravind Subramanian, Pablo Tamayo, Broad Institute
-commandLine=<run-with-env> -u "java/1.8" java <java_flags> \
+commandLine=<java> \
     -Djava.util.prefs.PreferencesFactory\=com.allaboutbalance.articles.disableprefs.DisabledPreferencesFactory \
     -Djava.awt.headless\=true \
     -cp <libdir>commons-lang3-3.4.jar<path.separator><libdir>commons-io-2.4.jar<path.separator><libdir>commons-cli-1.2.jar<path.separator><libdir>gp-gsea.jar<path.separator><libdir>disable-prefs.jar<path.separator><libdir>gsea-3.0.jar \
@@ -462,4 +462,4 @@ serializedModel=
 taskType=Gene List Selection
 category=beta
 userid=eby@broadinstitute.org
-version=Beta series: Updating to use the GSEA v3.0 open-source code base.  Unified the Gene Set DB selector parameters and better downloading of MSigDB files.  Added selected.gene.sets, alt.delim, creat.gcts and create.svgs parameters.  Better temp file clean-up and other internal code improvements.  Open-source release.
+version=set 'commandLine=<java> -Djava.util.p...', workaround for custom job.memory


### PR DESCRIPTION
Set `commandLine=<java>...` as a workaround for GP-5931. The custom job.memory drop-down does not *yet* work with the `<run-with-env> -u java/1.8 java <java_args>` substitution. 

This is an edit of the commandLine from the 'v19.0.18_beta' tag, to be merged into the 'beta' branch. 
It duplicates the 'hand crafted' v19.0.19 that was tested on the gp-beta-ami server.
